### PR TITLE
Demonstrate multi-line comment reconstruction

### DIFF
--- a/zookeeper-jute/src/main/java/org/apache/jute/compiler/JField.java
+++ b/zookeeper-jute/src/main/java/org/apache/jute/compiler/JField.java
@@ -18,6 +18,9 @@
 
 package org.apache.jute.compiler;
 
+import org.apache.jute.compiler.generated.RccConstants;
+import org.apache.jute.compiler.generated.Token;
+
 /**
  *
  */
@@ -26,11 +29,40 @@ public class JField {
     private String mName;
 
     /**
+     * {@link #mType} of token.
+     */
+    private Token mTypeToken;
+
+    /**
+     * Since we can only get the comments before the token through the {@link Token#specialToken},
+     * we need to save the next token to get the end-of-line comment.
+     *
+     * <p>It may be the type of the next field, or it may be {@link RccConstants#RBRACE_TKN} of the class.
+     */
+    private Token nextToken;
+
+    /**
      * Creates a new instance of JField.
      */
     public JField(JType type, String name) {
         mType = type;
         mName = name;
+    }
+
+    public Token getTypeToken() {
+        return mTypeToken;
+    }
+
+    public void setTypeToken(Token typeToken) {
+        this.mTypeToken = typeToken;
+    }
+
+    public Token getNextToken() {
+        return nextToken;
+    }
+
+    public void setNextToken(Token nextToken) {
+        this.nextToken = nextToken;
     }
 
     public String getSignature() {

--- a/zookeeper-jute/src/main/java/org/apache/jute/compiler/generated/rcc.jj
+++ b/zookeeper-jute/src/main/java/org/apache/jute/compiler/generated/rcc.jj
@@ -37,6 +37,8 @@ public class Rcc {
     private static String curDir = System.getProperty("user.dir");
     private static String curFileName;
     private static String curModuleName;
+    private Token tmpToken = null;
+    private JField prevField = null;
 
     public static void main(String args[]) {
         String language = "java";
@@ -97,6 +99,12 @@ public class Rcc {
             }
         }
     }
+
+    private void prevFieldSetNextTkn(Token token) {
+        if (prevField != null) {
+            prevField.setNextToken(token);
+        }
+    }
 }
 
 PARSER_END(Rcc)
@@ -111,17 +119,7 @@ SKIP :
 
 SPECIAL_TOKEN :
 {
-  "//" : WithinOneLineComment
-}
-
-<WithinOneLineComment> SPECIAL_TOKEN :
-{
-  <("\n" | "\r" | "\r\n" )> : DEFAULT
-}
-
-<WithinOneLineComment> MORE :
-{
-  <~[]>
+  <WithinOneLineComment: "//" (~["\n","\r"])* ("\n"|"\r"|"\r\n")>
 }
 
 SPECIAL_TOKEN :
@@ -246,7 +244,10 @@ String ModuleName() :
 }
 {
     t = <IDENT_TKN>
-    { name += t.image; }
+    {
+        tmpToken = t;
+        name += t.image;
+    }
     (
         <DOT_TKN>
         t = <IDENT_TKN>
@@ -274,22 +275,37 @@ JRecord Record() :
     ArrayList<JField> flist = new ArrayList<JField>();
     Token t;
     JField f;
+    // Get the comments on the class token
+    Token recordTkn;
+    Token rbraceTkn;
 }
 {
-    <RECORD_TKN>
+    recordTkn = <RECORD_TKN>
     t = <IDENT_TKN>
     { rname = t.image; }
     <LBRACE_TKN>
     (
         f = Field()
-        { flist.add(f); }
+        {
+            flist.add(f);
+        }
         <SEMICOLON_TKN>
+        {
+            f.setTypeToken(tmpToken);
+            prevFieldSetNextTkn(tmpToken);
+            prevField = f;
+            tmpToken = null;
+        }
     )+
-    <RBRACE_TKN>
+
+    // Get the line ending comment of the last attribute
+    rbraceTkn = <RBRACE_TKN>
     {
         String fqn = curModuleName + "." + rname;
-        JRecord r = new JRecord(fqn, flist);
+        JRecord r = new JRecord(fqn, flist, recordTkn);
         recTab.put(fqn, r);
+        prevFieldSetNextTkn(rbraceTkn);
+        prevField = null;
         return r;
     }
 }
@@ -308,30 +324,28 @@ JField Field() :
 JType Type() :
 {
     JType jt;
-    Token t;
+    Token t = null;
     String rname;
 }
 {
-    jt = Map()
-    { return jt; }
+    (jt = Map()
 |   jt = Vector()
-    { return jt; }
-|   <BYTE_TKN>
-    { return new JByte(); }
-|   <BOOLEAN_TKN>
-    { return new JBoolean(); }
-|   <INT_TKN>
-    { return new JInt(); }
-|   <LONG_TKN>
-    { return new JLong(); }
-|   <FLOAT_TKN>
-    { return new JFloat(); }
-|   <DOUBLE_TKN>
-    { return new JDouble(); }
-|   <USTRING_TKN>
-    { return new JString(); }
-|   <BUFFER_TKN>
-    { return new JBuffer(); }
+|   t = <BYTE_TKN>
+    { jt = new JByte(); }
+|   t = <BOOLEAN_TKN>
+    { jt = new JBoolean(); }
+|   t = <INT_TKN>
+    { jt = new JInt(); }
+|   t = <LONG_TKN>
+    { jt = new JLong(); }
+|   t = <FLOAT_TKN>
+    { jt = new JFloat(); }
+|   t = <DOUBLE_TKN>
+    { jt = new JDouble(); }
+|   t = <USTRING_TKN>
+    { jt = new JString(); }
+|   t = <BUFFER_TKN>
+    { jt = new JBuffer(); }
 |   rname = ModuleName()
     {
         if (rname.indexOf('.', 0) < 0) {
@@ -343,6 +357,13 @@ JType Type() :
             System.exit(1);
         }
         return r;
+    })
+
+    {
+        if (t != null) {
+            tmpToken = t;
+        }
+        return jt;
     }
 }
 
@@ -350,25 +371,33 @@ JMap Map() :
 {
     JType jt1;
     JType jt2;
+    Token t;
 }
 {
-    <MAP_TKN>
+    t = <MAP_TKN>
     <LT_TKN>
     jt1 = Type()
     <COMMA_TKN>
     jt2 = Type()
     <GT_TKN>
-    { return new JMap(jt1, jt2); }
+    {
+        tmpToken = t;
+        return new JMap(jt1, jt2);
+    }
 }
 
 JVector Vector() :
 {
     JType jt;
+    Token t;
 }
 {
-    <VECTOR_TKN>
+    t = <VECTOR_TKN>
     <LT_TKN>
     jt = Type()
     <GT_TKN>
-    { return new JVector(jt); }
+    {
+        tmpToken = t;
+        return new JVector(jt);
+    }
 }

--- a/zookeeper-jute/src/main/java/org/apache/jute/compiler/generated/rcc.jj
+++ b/zookeeper-jute/src/main/java/org/apache/jute/compiler/generated/rcc.jj
@@ -119,22 +119,8 @@ SKIP :
 
 SPECIAL_TOKEN :
 {
-  <WithinOneLineComment: "//" (~["\n","\r"])* ("\n"|"\r"|"\r\n")>
-}
-
-SPECIAL_TOKEN :
-{
-  "/*" : WithinMultiLineComment
-}
-
-<WithinMultiLineComment> SPECIAL_TOKEN :
-{
-  "*/" : DEFAULT
-}
-
-<WithinMultiLineComment> MORE :
-{
-  <~[]>
+    <ONE_LINE_COMMENT: "//" (~["\n","\r"])*>
+|   <MULTI_LINE_COMMENT: "/*" (~["*"])* "*" (~["*","/"] (~["*"])* "*" | "*")* "/">
 }
 
 TOKEN :

--- a/zookeeper-jute/src/main/resources/zookeeper.jute
+++ b/zookeeper-jute/src/main/resources/zookeeper.jute
@@ -17,8 +17,36 @@
  */
 
 module org.apache.zookeeper.data {
+    /*
+     * Something.
+     */
     class Id {
-        ustring scheme;
+        /**
+         * Schema.
+         */
+        ustring scheme; /* End of line
+         * for test purpose.
+         */
+        // ## Paragraph 1
+        // Something important.
+
+        // ## Paragraph 2
+        //
+        // Something else.
+
+        /*
+        * Paragraph 3.
+        */
+
+        /*
+         * Paragraph 4.
+
+         */
+
+        /**
+
+         ** Paragraph 5.
+         **/
         ustring id;
     }
     class ACL {

--- a/zookeeper-jute/src/test/java/org/apache/jute/compiler/JRecordTest.java
+++ b/zookeeper-jute/src/test/java/org/apache/jute/compiler/JRecordTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jute.compiler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.io.StringReader;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.apache.jute.compiler.generated.ParseException;
+import org.apache.jute.compiler.generated.Rcc;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings({"unchecked", "SameParameterValue"})
+public class JRecordTest {
+
+    @Test
+    public void testEndOfLineComments() throws ParseException, NoSuchFieldException, IllegalAccessException {
+        String juteStr = "module org.apache.zookeeper.data {\n"
+                + "    // information explicitly stored by the server persistently\n"
+                + "    class StatPersisted {\n"
+                + "        long czxid;      // created zxid\n"
+                + "        long mzxid;      // last modified zxid\n"
+                + "        long ctime;      // created\n"
+                + "        long mtime;      // last modified\n"
+                + "    }\n"
+                + "}";
+
+        try (StringReader stringReader = new StringReader(juteStr)) {
+            Rcc parser = new Rcc(stringReader);
+            JFile jFile = parser.Input();
+            List<JRecord> mRecords = getField(jFile, "mRecords", List.class);
+            assertEquals(1, mRecords.size());
+
+            JRecord jRecord = mRecords.get(0);
+            assertEquals("StatPersisted", jRecord.getName());
+            List<JField> fields = jRecord.getFields();
+            assertFiled(fields);
+
+            assertEquals("\n// information explicitly stored by the server persistently\n", jRecord.getRecordComments());
+            assertEquals("\n  // created zxid\n", jRecord.getJavaFieldComments(fields.get(0)));
+            assertEquals("\n  // last modified zxid\n", jRecord.getJavaFieldComments(fields.get(1)));
+            assertEquals("\n  // created\n", jRecord.getJavaFieldComments(fields.get(2)));
+            assertEquals("\n  // last modified\n", jRecord.getJavaFieldComments(fields.get(3)));
+        }
+    }
+
+    @Test
+    public void testCommentBeforeLine() throws ParseException, NoSuchFieldException, IllegalAccessException {
+        String juteStr = "module org.apache.zookeeper.data {\n"
+                + "    // information explicitly stored by the server persistently\n"
+                + "    class StatPersisted {\n"
+                + "        // created zxid\n"
+                + "        long czxid;\n"
+                + "        // last modified zxid\n"
+                + "        long mzxid;\n"
+                + "        // created\n"
+                + "        long ctime;\n"
+                + "        // last modified\n"
+                + "        long mtime;\n"
+                + "    }\n"
+                + "}";
+        try (StringReader stringReader = new StringReader(juteStr)) {
+            Rcc parser = new Rcc(stringReader);
+            JFile jFile = parser.Input();
+            List<JRecord> mRecords = getField(jFile, "mRecords", List.class);
+            assertEquals(1, mRecords.size());
+
+            JRecord jRecord = mRecords.get(0);
+            assertEquals("StatPersisted", jRecord.getName());
+            List<JField> fields = jRecord.getFields();
+            assertFiled(fields);
+
+            assertEquals("\n// information explicitly stored by the server persistently\n", jRecord.getRecordComments());
+            assertEquals("\n  // created zxid\n", jRecord.getJavaFieldComments(fields.get(0)));
+            assertEquals("\n  // last modified zxid\n", jRecord.getJavaFieldComments(fields.get(1)));
+            assertEquals("\n  // created\n", jRecord.getJavaFieldComments(fields.get(2)));
+            assertEquals("\n  // last modified\n", jRecord.getJavaFieldComments(fields.get(3)));
+        }
+    }
+
+    @Test
+    public void testMultiLineComments() throws ParseException, NoSuchFieldException, IllegalAccessException {
+        String juteStr = "module org.apache.zookeeper.data {\n"
+                + "    // information explicitly stored by the server persistently\n"
+                + "    class StatPersisted {\n"
+                + "        /**\n"
+                + "         * created zxid\n"
+                + "         */\n"
+                + "        long czxid;\n"
+                + "        /* last modified zxid */\n"
+                + "        long mzxid;\n"
+                + "        /*\n"
+                + "         * created\n"
+                + "         */\n"
+                + "        long ctime;\n"
+                + "        /*\n"
+                + "         last modified\n"
+                + "         */"
+                + "        long mtime;\n"
+                + "    }\n"
+                + "}";
+        try (StringReader stringReader = new StringReader(juteStr)) {
+            Rcc parser = new Rcc(stringReader);
+            JFile jFile = parser.Input();
+            List<JRecord> mRecords = getField(jFile, "mRecords", List.class);
+            assertEquals(1, mRecords.size());
+
+            JRecord jRecord = mRecords.get(0);
+            assertEquals("StatPersisted", jRecord.getName());
+            List<JField> fields = jRecord.getFields();
+            assertFiled(fields);
+
+            assertEquals("\n// information explicitly stored by the server persistently\n", jRecord.getRecordComments());
+            assertEquals("\n  /**\n  * created zxid\n  */\n", jRecord.getJavaFieldComments(fields.get(0)));
+            assertEquals("\n  /* last modified zxid */\n", jRecord.getJavaFieldComments(fields.get(1)));
+            assertEquals("\n  /*\n  * created\n  */\n", jRecord.getJavaFieldComments(fields.get(2)));
+            assertEquals("\n  /*\n  last modified\n  */\n", jRecord.getJavaFieldComments(fields.get(3)));
+        }
+    }
+
+    private void assertFiled(List<JField> fields) {
+        assertEquals(4, fields.size());
+        assertEquals("long", fields.get(0).getType().getJavaType());
+        assertEquals("czxid", fields.get(0).getName());
+        assertEquals("long", fields.get(1).getType().getJavaType());
+        assertEquals("mzxid", fields.get(1).getName());
+        assertEquals("long", fields.get(2).getType().getJavaType());
+        assertEquals("ctime", fields.get(2).getName());
+        assertEquals("long", fields.get(3).getType().getJavaType());
+        assertEquals("mtime", fields.get(3).getName());
+    }
+
+    private <T> T getField(final Object target,
+                           final String fieldName,
+                           final Class<T> fieldClassType) throws NoSuchFieldException, IllegalAccessException {
+        Class<?> targetClazz = target.getClass();
+        Field field = targetClazz.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return fieldClassType.cast(field.get(target));
+    }
+}


### PR DESCRIPTION
Changes:
1. No change to one-line comment capture.
2. Change only indentation and line separator for multi-line comment.

The reconstruction might be a bit hard given the current comment capture from apache/zookeeper#2206. I am OK to both approches.